### PR TITLE
Decompose CLI into commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Generate service-oriented code from popular API definition languages.
 
+See the [project wiki](https://github.com/basketry/basketry/wiki) for a complete set of documentation and articles.
+
 ## Quick Start
 
 The following example converts a "Swagger" doc into Typescript types:
@@ -40,9 +42,9 @@ Add the following script to `package.json`:
 
 Now you can generate code by running `npm run basketry`. Note that you can mix and match CLI arguments and config file settings—CLI arguments will override the config file if the same setting is specified in both places.
 
-## CLI Usage
+## `generate` command
 
-Code can be generated using the `basketry` command.
+Generate code with the `basketry generate` command or just `basketry`.
 
 ### Source file
 
@@ -78,7 +80,7 @@ See the "How does it work?" section below for info on what values can be used as
 
 ### Generators
 
-Use `-g`, `--generators` to specify one or more generator to use:
+Use `-g`, `--generators` to specify one or more generators to use:
 
 ```
 basketry --generators @basketry/typescript
@@ -120,7 +122,7 @@ basketry --source src/petstore.json --watch
 
 You can also run Basketry in watch mode by passing the `-w` option to an npm script: `npm run basketry -- -w`. While in watch mode, Basketry will re-run all rules and generators whenever the source file is updated.
 
-### Validate only
+### Validate only (deprecated)
 
 Use `-v`, `--validate` to only run the parser and rules but skip file generation:
 
@@ -138,65 +140,17 @@ basketry --json
 
 Note that `--json` cannot be used with `--watch`.
 
-## How does it work?
+## `validate` command
 
-Internally, basketry is a plugable pipeline that translates a service from a Service Definition Language (SDL) to one or more programatic or human readable langugages. The first step is to use a Parser to convert and SDL in an Intermediate Representation (IR) of the service. In the second step, this IR is passed to one or more Generators which convert the IR into the final target language.
+Validate the source per the supplied rules with the `basketry validate` command (previously `basketry --validate`). This command will run the parser and rules, but will not generate any files.
 
-Basketry coordinates the pipeline and writes the resulting output to the file system. It also exposes an lightweight set of types and tools to build custom Parsers and Generators. By decoupling the SDL parsing and code generating steps, Parsers and Generators can be easily mixed and matched.
+This command takes the same `source`, `parser`, `rules`, `config`, `json`, and `perf` arguments as the `generate` command.
 
-### Parser
+## `clean` command
 
-A "Parser" is a JavaScript module whose default export is a parsing function that converts in input SDL into the intermediate representation of a Service:
+Remove previously generated files with the `basketry clean` command.
 
-```ts
-type Parser = (content: string, path: string) => { service: Service };
-
-const parser: Parser = (content, path) => {
-  // Parser implementation goes here
-};
-
-export default parser;
-```
-
-### Generators
-
-A "Generator" is a JavaScript module whose default export is a generator function that converts in input intermediate representation of the service into one or more files:
-
-```ts
-type Generator = (service: Service) => File[];
-
-const generator: Generator = (service) => {
-  // Generator implementation goes here
-};
-
-export default generator;
-```
-
-### Rules
-
-A "Rule" is a JavaScript module whose default export is a rule function that looks at the intermediate representation of a service and returns an array of any rule violations:
-
-```ts
-type Rule = (service: Service, path: string) => Violation[];
-
-const rule: Rule = (service, path) => {
-  // Rule implementation goes here
-};
-
-export default rule;
-```
-
-Rules can be used to enforce specific opinions about service design. For example, a rule could enforce names and types for paging parameters. Another rule might establish a naming convention for method and types.
-
-Note that rules are run against the Intermediate Representation (IR); therefore, any rule may be used with any Basketry parser. The IR contains source map data which allows the violations to point to specific ranges of the source Serivce Definition without needing to implement the same rule for each SDL.
-
-### Using parsers, generators, and rules
-
-Any string that can be used to "require" a CommonJS module can be used to specify a parser, generator, or rule.
-
-For example, any parser (as described above) that can be required with `const myParser = require('./path/to/my/parser')` can be used with Basketry with `basketry --parser ./path/to/my/parser`. This applies to both modules defined within your project and packages installed from NPM. If it can be required from within your project, it can be used as a Parser, Generator, or Rule.
-
-Although Basketry is written in the JavaScript family of languages, it can be used to generate code in any language.
+This command takes the same `config` and `output` arguments as the `generate` command.
 
 ## Advanced Usage
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "url": "https://github.com/basketry/basketry/issues"
   },
   "homepage": "https://github.com/basketry/basketry/wiki",
+  "funding": "https://github.com/basketry/basketry?sponsor=1",
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.10",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,97 +1,14 @@
 #!/usr/bin/env node
 
-import { readFileSync, StatWatcher, watchFile } from 'fs';
-import { EOL, type } from 'os';
-import { performance, PerformanceEntry, PerformanceObserver } from 'perf_hooks';
-
-import Ajv from 'ajv';
-import chalk from 'chalk';
 import { hideBin } from 'yargs/helpers';
-
-import schema from './config-schema.json';
-import { BasketryError, Violation, FileStatus, CliOutput } from './types';
-import { getInput, run, writeFiles } from './engine';
-
-let events: PerformanceEntry[] = [];
-const performanceObserver = new PerformanceObserver((items, observer) => {
-  events.push(...items.getEntries());
-
-  if (done) {
-    if (j) {
-      console.log(JSON.stringify({ ...cliOutput, perf: events }));
-    } else {
-      printPerformance();
-    }
-
-    observer.disconnect();
-  }
-});
-
-let cliOutput: CliOutput = { errors: [], files: {}, violations: [] };
-let done = false;
-let j = false;
-
 import yargs = require('yargs/yargs');
+import chalk from 'chalk';
 
-const ajv = new Ajv({ allErrors: false });
-const runner = ajv.compile(schema);
+import { clean, generate, validate } from './commands';
 
 const { argv } = yargs(hideBin(process.argv))
-  .option('config', {
-    alias: 'c',
-    string: true,
-    description: 'Path to the config file. Defaults to basketry.conifg.json.',
-    default: 'basketry.config.json',
-    requiresArg: true,
-  })
-  .option('parser', {
-    alias: 'p',
-    string: true,
-    description: 'The parser',
-    requiresArg: true,
-  })
-  .option('source', {
-    alias: 's',
-    string: true,
-    description:
-      'Path to an SDL file. Reads from stdin if omitted and config is not found.',
-    requiresArg: true,
-  })
-  .option('output', {
-    alias: 'o',
-    string: true,
-    description:
-      'Path of the output folder. Writes to the current working directory if omitted and config is not found.',
-    requiresArg: true,
-  })
-  .option('generators', {
-    alias: 'g',
-    string: true,
-    array: true,
-    description: `Generators`,
-    requiresArg: true,
-  })
-  .option('rules', {
-    alias: 'r',
-    string: true,
-    array: true,
-    description: `Rules`,
-    requiresArg: true,
-  })
-  .option('watch', {
-    alias: 'w',
-    boolean: true,
-    description: 'Recreates the output each time the input file changes.',
-    nargs: 0,
-  })
-  .option('validate', {
-    alias: 'v',
-    boolean: true,
-    default: false,
-    description:
-      'Only validates the source document without writing any files.',
-    nargs: 0,
-  })
+  .strictCommands()
+  .version(chalk.bold(`🧺 Basketry v${require('../package.json').version}`))
   .option('json', {
     alias: 'j',
     boolean: true,
@@ -104,251 +21,164 @@ const { argv } = yargs(hideBin(process.argv))
     default: false,
     description: 'Report performance',
     nargs: 0,
-  });
-
-(async () => {
-  let p = false;
-  const errors: BasketryError[] = [];
-  const violations: Violation[] = [];
-  let files: Record<string, FileStatus> = {};
-
-  try {
-    const {
-      config,
-      parser,
-      source,
-      output,
-      generators,
-      rules,
-      watch,
-      validate,
-      json,
-      perf,
-    } = await argv;
-    j = json;
-    p = perf;
-
-    if (perf) performanceObserver.observe({ type: 'measure' });
-
-    performance.mark('basketry-start');
-    const stdin = !process.stdin.isTTY;
-    if (!j) bold(`🧺 Basketry v${require('../package.json').version}`);
-
-    const sourceContent = stdin
-      ? await readStreamToString(process.stdin)
-      : undefined;
-
-    let watcher: StatWatcher | undefined = undefined;
-
-    const go = async () => {
-      const inputs = await getInput(config, {
-        output,
-        validate,
-        generators,
+  })
+  .command(
+    ['generate', '*'],
+    'Generates files from a service definition',
+    (y) => {
+      return y
+        .option('config', {
+          alias: 'c',
+          string: true,
+          description:
+            'Path to the config file. Defaults to basketry.conifg.json.',
+          default: 'basketry.config.json',
+          requiresArg: true,
+        })
+        .option('parser', {
+          alias: 'p',
+          string: true,
+          description: 'The parser',
+          requiresArg: true,
+        })
+        .option('source', {
+          alias: 's',
+          string: true,
+          description:
+            'Path to an SDL file. Reads from stdin if omitted and config is not found.',
+          requiresArg: true,
+        })
+        .option('output', {
+          alias: 'o',
+          string: true,
+          description:
+            'Path of the output folder. Writes to the current working directory if omitted and config is not found.',
+          requiresArg: true,
+        })
+        .option('generators', {
+          alias: 'g',
+          string: true,
+          array: true,
+          description: `Generators`,
+          requiresArg: true,
+        })
+        .option('rules', {
+          alias: 'r',
+          string: true,
+          array: true,
+          description: `Rules`,
+          requiresArg: true,
+        })
+        .option('validate', {
+          alias: 'v',
+          deprecated: 'Use the "validate" command.',
+          boolean: true,
+          default: false,
+          description:
+            'Only validates the source document without writing any files.',
+          nargs: 0,
+        })
+        .option('watch', {
+          alias: 'w',
+          boolean: true,
+          description: 'Recreates the output each time the input file changes.',
+          nargs: 0,
+        });
+    },
+    (args) => {
+      const {
+        config,
         parser,
+        source,
+        output,
+        generators,
         rules,
-        sourceContent,
-        sourcePath: source,
+        watch,
+        validate: v,
+        json,
+        perf,
+      } = args;
+      generate({
+        config,
+        parser,
+        source,
+        output,
+        generators,
+        rules,
+        watch,
+        validate: v,
+        json,
+        perf,
       });
-      errors.push(...inputs.errors);
-      if (!j) printErrors(inputs.errors);
-
-      // TODO: fail if multiplexed with stdin (#24)
-
-      for (const input of inputs.values) {
-        if (!j) console.log(info(`Parsing ${input.sourcePath}`));
-        const result = run(input);
-        errors.push(...result.errors);
-        if (!j) printErrors(result.errors);
-
-        violations.push(...result.violations);
-        if (!j) printViolations(result.violations, validate);
-
-        const writeResult = await writeFiles(result.files);
-        errors.push(...writeResult.errors);
-        files = writeResult.value;
-        if (!j && !validate) printFiles(writeResult.value);
-        done = true;
-      }
-
-      if (!watcher && watch && !stdin && !json) {
-        for (const input of inputs.values) {
-          let timer: NodeJS.Timeout | undefined = undefined;
-          watcher = watchFile(input.sourcePath, () => {
-            if (timer) clearTimeout(timer);
-            timer = setTimeout(go, 100);
-          });
-        }
-      }
-    };
-
-    await go();
-  } catch (ex) {
-    error('FATAL ERROR!', ex.message);
-    process.exit(1);
-  } finally {
-    performance.mark('basketry-end');
-    performance.measure('basketry', 'basketry-start', 'basketry-end');
-
-    process.nextTick(() => {
-      if (j) {
-        cliOutput = { errors, violations, files };
-        done = true;
-        if (!p) console.log(JSON.stringify(cliOutput));
-      } else if (errors.length) {
-        process.exit(1);
-      }
-    });
-  }
-})();
-
-function bold(message: string): void {
-  console.log(chalk.bold(message));
-}
-
-function info(...text: unknown[]) {
-  return chalk.blueBright(text);
-}
-
-function warning(...text: unknown[]) {
-  return chalk.yellow(text);
-}
-
-async function readStreamToString(stream: NodeJS.ReadStream) {
-  const chunks: any[] = [];
-  for await (const chunk of stream) chunks.push(chunk);
-  return Buffer.concat(chunks).toString('utf8');
-}
-
-function error(...lines: string[]): void {
-  console.error();
-  for (const line of lines) {
-    console.error(chalk.bold.red(line));
-  }
-  console.error();
-}
-
-function printViolations(violations: Violation[], validateOnly: boolean): void {
-  if (violations.length) {
-    const contentBySource = new Map<string, string[]>();
-
-    for (const violation of violations) {
-      const { start, end } = violation.range;
-
-      if (!contentBySource.has(violation.sourcePath)) {
-        contentBySource.set(
-          violation.sourcePath,
-          readFileSync(violation.sourcePath).toString().split(EOL),
-        );
-      }
-      const line = contentBySource.get(violation.sourcePath)![start.line - 1];
-      const violationLength =
-        start.line === end.line
-          ? end.column - start.column
-          : line.length - start.column + 1;
-
-      console.error();
-      console.error(
-        `${chalk.cyan(violation.sourcePath)}:${warning(start.line)}:${warning(
-          start.column,
-        )}`,
-      );
-      let severity: string;
-      let underline: string;
-
-      switch (violation.severity) {
-        case 'info':
-          severity = info(violation.severity);
-          underline = info('~'.repeat(violationLength));
-          break;
-        case 'warning':
-          severity = warning(violation.severity);
-          underline = warning('~'.repeat(violationLength));
-          break;
-        case 'error':
-          severity = chalk.redBright(violation.severity);
-          underline = chalk.redBright('~'.repeat(violationLength));
-          break;
-      }
-
-      console.error(
-        `${severity} ${chalk.gray(`${violation.code}:`)} ${violation.message}`,
-      );
-      console.error();
-      console.error(`${chalk.bgWhite.black(start.line)}${line}`);
-      console.error(
-        `${chalk.bgWhite.black(' '.repeat(`${start.line}`.length))}${' '.repeat(
-          start.column - 1,
-        )}${underline}`,
-      );
-    }
-    console.error();
-  } else if (validateOnly) {
-    console.log(info('No violations'));
-    console.log();
-  }
-}
-
-function printErrors(errors: BasketryError[]): void {
-  for (const e of errors) {
-    console.error();
-    console.error(e);
-  }
-}
-
-function printFiles(files: Record<string, FileStatus>): void {
-  if (Object.keys(files).some((file) => files[file] !== 'no-change')) {
-    console.log();
-    for (const file in files) {
-      switch (files[file]) {
-        case 'added':
-          console.log(chalk.green(`+ ${file}`));
-          break;
-        case 'error':
-          console.log(chalk.bold.red(`E ${file}`));
-          break;
-        case 'modified':
-          console.log(info(`m ${file}`));
-          break;
-        case 'removed':
-          console.log(chalk.bold.red(`- ${file}`));
-          break;
-      }
-    }
-  } else {
-    console.log(info('No changes'));
-  }
-  console.log();
-}
-
-export function validateConfig(service: any): boolean {
-  return runner(service);
-}
-
-function printPerformance() {
-  console.log('⌛ Component Performance:');
-  console.log();
-  for (const event of events.sort((a, b) => b.duration - a.duration)) {
-    if (event.detail && ['rule', 'parser', 'generator'].includes(event.name)) {
-      let ms = `(${Math.round(event.duration)}ms)`;
-
-      if (event.duration > 100) {
-        ms = chalk.red(ms);
-      } else if (event.duration > 50) {
-        ms = warning(ms);
-      } else {
-        ms = chalk.greenBright(ms);
-      }
-
-      const line = `   ${pad(`${event.name}:`, 10)} ${event.detail} ${ms}`;
-
-      console.log(line);
-    }
-  }
-  events = [];
-  console.log();
-}
-
-function pad(text: string, length: number): string {
-  return `${text}${' '.repeat(length)}`.substring(0, length);
-}
+    },
+  )
+  .command(
+    'clean',
+    'Remove all generated files',
+    (y) => {
+      return y
+        .option('config', {
+          alias: 'c',
+          string: true,
+          description:
+            'Path to the config file. Defaults to basketry.conifg.json.',
+          default: 'basketry.config.json',
+          requiresArg: true,
+        })
+        .option('output', {
+          alias: 'o',
+          string: true,
+          description:
+            'Path of the output folder. Writes to the current working directory if omitted and config is not found.',
+          requiresArg: true,
+        });
+    },
+    (args) => {
+      const { config, output, json, perf } = args;
+      clean({
+        config,
+        output,
+        json,
+        perf,
+      });
+    },
+  )
+  .command(
+    ['validate'],
+    'Validates the source document without generating any files',
+    (y) => {
+      return y
+        .option('config', {
+          alias: 'c',
+          string: true,
+          description:
+            'Path to the config file. Defaults to basketry.conifg.json.',
+          default: 'basketry.config.json',
+          requiresArg: true,
+        })
+        .option('parser', {
+          alias: 'p',
+          string: true,
+          description: 'The parser',
+          requiresArg: true,
+        })
+        .option('source', {
+          alias: 's',
+          string: true,
+          description:
+            'Path to an SDL file. Reads from stdin if omitted and config is not found.',
+          requiresArg: true,
+        })
+        .option('rules', {
+          alias: 'r',
+          string: true,
+          array: true,
+          description: `Rules`,
+          requiresArg: true,
+        });
+    },
+    (args) => {
+      const { config, parser, source, rules, json, perf } = args;
+      validate({ config, parser, source, rules, json, perf });
+    },
+  );

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,0 +1,82 @@
+import { readFile, unlink } from 'fs/promises';
+import { relative, resolve } from 'path';
+
+import chalk from 'chalk';
+
+import { getInput } from '../engine';
+import { BasketryError } from '../types';
+import { CommmonArgs } from './types';
+
+export type CleanArgs = {
+  config: string;
+  output?: string;
+} & CommmonArgs;
+
+export async function clean(args: CleanArgs) {
+  console.log(
+    chalk.bold(`🧺 Basketry v${require('../../package.json').version}`),
+  );
+  console.log();
+  const errors: BasketryError[] = [];
+
+  const { config, output } = args;
+
+  const result = await getInput(config, { output });
+  errors.push(...result.errors);
+
+  const files: string[] = [];
+
+  for (const input of result.values) {
+    files.push(...(await getFiles(input.output)));
+  }
+
+  if (files.length) {
+    let removed = 0;
+
+    for (const file of files) {
+      try {
+        await unlink(file);
+        console.log(chalk.bold.red(`- ${relative(process.cwd(), file)}`));
+        removed++;
+      } catch {
+        console.log(chalk.gray(`? ${relative(process.cwd(), file)}`));
+      }
+    }
+
+    console.log();
+    console.log(`Removed ${removed} files.`);
+  } else {
+    console.log(`Nothing to do.`);
+  }
+  console.log();
+}
+
+async function getFiles(output?: string): Promise<string[]> {
+  const root = resolve(process.cwd(), output || '');
+  const path = resolve(root, '.gitattributes');
+
+  let file: string | undefined;
+  try {
+    file = (await readFile(path)).toString();
+  } catch {
+    return [];
+  }
+
+  const generatedFiles = [
+    ...file
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(
+        (line) =>
+          !line.startsWith('#') &&
+          (line.endsWith('linguist-generated') ||
+            line.endsWith('linguist-generated=true')),
+      )
+      .map((line) =>
+        line.substring(0, line.indexOf('linguist-generated')).trim(),
+      ),
+    '.gitattributes',
+  ].map((f) => resolve(root, f));
+
+  return generatedFiles;
+}

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,0 +1,290 @@
+import { readFileSync, StatWatcher, watchFile } from 'fs';
+import { EOL } from 'os';
+import { performance, PerformanceEntry, PerformanceObserver } from 'perf_hooks';
+
+import Ajv from 'ajv';
+import chalk from 'chalk';
+
+import schema from '../config-schema.json';
+import { BasketryError, CliOutput, FileStatus, Violation } from '../types';
+import { getInput, run, writeFiles } from '../engine';
+import { CommmonArgs } from './types';
+
+let events: PerformanceEntry[] = [];
+const performanceObserver = new PerformanceObserver((items, observer) => {
+  events.push(...items.getEntries());
+
+  if (done) {
+    if (j) {
+      console.log(JSON.stringify({ ...cliOutput, perf: events }));
+    } else {
+      printPerformance();
+    }
+
+    observer.disconnect();
+  }
+});
+let cliOutput: CliOutput = { errors: [], files: {}, violations: [] };
+let done = false;
+let j = false;
+
+const ajv = new Ajv({ allErrors: false });
+const runner = ajv.compile(schema);
+
+export type GenerateArgs = {
+  config: string;
+  source?: string;
+  parser?: string;
+  rules?: string[];
+  validate?: boolean;
+  generators?: string[];
+  output?: string;
+  watch?: boolean;
+} & CommmonArgs;
+
+export async function generate(args: GenerateArgs) {
+  let p = false;
+  const errors: BasketryError[] = [];
+  const violations: Violation[] = [];
+  let files: Record<string, FileStatus> = {};
+
+  try {
+    const {
+      config,
+      parser,
+      source,
+      output,
+      generators,
+      rules,
+      watch,
+      validate,
+      json,
+      perf,
+    } = args;
+    j = json || false;
+    p = perf || false;
+
+    if (perf) performanceObserver.observe({ type: 'measure' });
+
+    performance.mark('basketry-start');
+    const stdin = !process.stdin.isTTY;
+    if (!j) bold(`🧺 Basketry v${require('../../package.json').version}`);
+
+    const sourceContent = stdin
+      ? await readStreamToString(process.stdin)
+      : undefined;
+
+    let watcher: StatWatcher | undefined = undefined;
+
+    const go = async () => {
+      const inputs = await getInput(config, {
+        output,
+        validate: false,
+        generators,
+        parser,
+        rules,
+        sourceContent,
+        sourcePath: source,
+      });
+      errors.push(...inputs.errors);
+      if (!j) printErrors(inputs.errors);
+
+      // TODO: fail if multiplexed with stdin (#24)
+
+      for (const input of inputs.values) {
+        if (!j) console.log(info(`Parsing ${input.sourcePath}`));
+        const result = run(input);
+        errors.push(...result.errors);
+        if (!j) printErrors(result.errors);
+
+        violations.push(...result.violations);
+        if (!j) printViolations(result.violations, validate || false);
+
+        const writeResult = await writeFiles(result.files);
+        errors.push(...writeResult.errors);
+        files = writeResult.value;
+        if (!j && !validate) printFiles(writeResult.value);
+        done = true;
+      }
+
+      if (!watcher && watch && !stdin && !json) {
+        for (const input of inputs.values) {
+          let timer: NodeJS.Timeout | undefined = undefined;
+          watcher = watchFile(input.sourcePath, () => {
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(go, 100);
+          });
+        }
+      }
+    };
+
+    await go();
+  } catch (ex) {
+    error('FATAL ERROR!', ex.message);
+    process.exit(1);
+  } finally {
+    performance.mark('basketry-end');
+    performance.measure('basketry', 'basketry-start', 'basketry-end');
+
+    process.nextTick(() => {
+      if (j) {
+        cliOutput = { errors, violations, files };
+        done = true;
+        if (!p) console.log(JSON.stringify(cliOutput));
+      } else if (errors.length) {
+        process.exit(1);
+      }
+    });
+  }
+}
+
+function bold(message: string): void {
+  console.log(chalk.bold(message));
+}
+
+function info(...text: unknown[]) {
+  return chalk.blueBright(text);
+}
+
+function warning(...text: unknown[]) {
+  return chalk.yellow(text);
+}
+
+async function readStreamToString(stream: NodeJS.ReadStream) {
+  const chunks: any[] = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function error(...lines: string[]): void {
+  console.error();
+  for (const line of lines) {
+    console.error(chalk.bold.red(line));
+  }
+  console.error();
+}
+
+function printViolations(violations: Violation[], validateOnly: boolean): void {
+  if (violations.length) {
+    const contentBySource = new Map<string, string[]>();
+
+    for (const violation of violations) {
+      const { start, end } = violation.range;
+
+      if (!contentBySource.has(violation.sourcePath)) {
+        contentBySource.set(
+          violation.sourcePath,
+          readFileSync(violation.sourcePath).toString().split(EOL),
+        );
+      }
+      const line = contentBySource.get(violation.sourcePath)![start.line - 1];
+      const violationLength =
+        start.line === end.line
+          ? end.column - start.column
+          : line.length - start.column + 1;
+
+      console.error();
+      console.error(
+        `${chalk.cyan(violation.sourcePath)}:${warning(start.line)}:${warning(
+          start.column,
+        )}`,
+      );
+      let severity: string;
+      let underline: string;
+
+      switch (violation.severity) {
+        case 'info':
+          severity = info(violation.severity);
+          underline = info('~'.repeat(violationLength));
+          break;
+        case 'warning':
+          severity = warning(violation.severity);
+          underline = warning('~'.repeat(violationLength));
+          break;
+        case 'error':
+          severity = chalk.redBright(violation.severity);
+          underline = chalk.redBright('~'.repeat(violationLength));
+          break;
+      }
+
+      console.error(
+        `${severity} ${chalk.gray(`${violation.code}:`)} ${violation.message}`,
+      );
+      console.error();
+      console.error(`${chalk.bgWhite.black(start.line)}${line}`);
+      console.error(
+        `${chalk.bgWhite.black(' '.repeat(`${start.line}`.length))}${' '.repeat(
+          start.column - 1,
+        )}${underline}`,
+      );
+    }
+    console.error();
+  } else if (validateOnly) {
+    console.log(info('No violations'));
+    console.log();
+  }
+}
+
+function printErrors(errors: BasketryError[]): void {
+  for (const e of errors) {
+    console.error();
+    console.error(e);
+  }
+}
+
+function printFiles(files: Record<string, FileStatus>): void {
+  if (Object.keys(files).some((file) => files[file] !== 'no-change')) {
+    console.log();
+    for (const file in files) {
+      switch (files[file]) {
+        case 'added':
+          console.log(chalk.green(`+ ${file}`));
+          break;
+        case 'error':
+          console.log(chalk.bold.red(`E ${file}`));
+          break;
+        case 'modified':
+          console.log(info(`m ${file}`));
+          break;
+        case 'removed':
+          console.log(chalk.bold.red(`- ${file}`));
+          break;
+      }
+    }
+  } else {
+    console.log(info('No changes'));
+  }
+  console.log();
+}
+
+export function validateConfig(service: any): boolean {
+  return runner(service);
+}
+
+function printPerformance() {
+  console.log('⌛ Component Performance:');
+  console.log();
+  for (const event of events.sort((a, b) => b.duration - a.duration)) {
+    if (event.detail && ['rule', 'parser', 'generator'].includes(event.name)) {
+      let ms = `(${Math.round(event.duration)}ms)`;
+
+      if (event.duration > 100) {
+        ms = chalk.red(ms);
+      } else if (event.duration > 50) {
+        ms = warning(ms);
+      } else {
+        ms = chalk.greenBright(ms);
+      }
+
+      const line = `   ${pad(`${event.name}:`, 10)} ${event.detail} ${ms}`;
+
+      console.log(line);
+    }
+  }
+  events = [];
+  console.log();
+}
+
+function pad(text: string, length: number): string {
+  return `${text}${' '.repeat(length)}`.substring(0, length);
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,3 @@
+export { clean } from './clean';
+export { generate } from './generate';
+export { validate } from './validate';

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,4 @@
+export type CommmonArgs = {
+  json?: boolean;
+  perf?: boolean;
+};

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,0 +1,13 @@
+import { generate } from '.';
+import { CommmonArgs } from './types';
+
+export type ValidateArgs = {
+  config: string;
+  source?: string;
+  parser?: string;
+  rules?: string[];
+} & CommmonArgs;
+
+export async function validate(args: ValidateArgs) {
+  generate({ ...args, validate: true });
+}


### PR DESCRIPTION
This change breaks the CLI up into separate commands. The commands are implemented by calling the command method from the Yargs builder. This sets up for future decomposition of the engine from the CLI.

This change is the first of a few changes that I eluded to in https://github.com/basketry/basketry/issues/32