### PR TITLE
Return only unique rule violations

### DIFF
--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -489,4 +489,20 @@ describe('engine', () => {
       files: [],
     });
   });
+
+  it('returns only unique rule violations', () => {
+    // ACT
+    const result = run({
+      sourcePath: 'some-file.ext',
+      sourceContent: 'some content',
+      configPath: 'some-config.ext',
+      parser: 'src/test-modules/parser',
+      generators: ['src/test-modules/generator'],
+      rules: ['src/test-modules/rule-that-returns-duplicate-violations'],
+      validate: false,
+    });
+
+    // ASSERT
+    expect(result.violations.length).toEqual(1);
+  });
 });

--- a/src/test-modules/rule-that-returns-duplicate-violations.ts
+++ b/src/test-modules/rule-that-returns-duplicate-violations.ts
@@ -1,0 +1,27 @@
+import { decodeRange } from '../helpers';
+import { Rule, Violation } from '../types';
+
+const rule: Rule = (_, sourcePath, options) => {
+  const violation: Violation = {
+    code: 'rule-that-returns-duplicate-violations',
+    message: 'some message',
+    range: {
+      start: {
+        offset: 2000,
+        line: 30,
+        column: 100,
+      },
+      end: {
+        offset: 2100,
+        line: 30,
+        column: 200,
+      },
+    },
+    severity: options?.severity || 'error',
+    sourcePath,
+  };
+
+  return [violation, violation, violation, violation];
+};
+
+export default rule;


### PR DESCRIPTION
Quite often, the same violation will be returned multiple times. This typically occurs when an invalid service component is reused in multiple places. When this happens, the violation related to the invalid component is presented once for each point of reuse.

The UX for this is poor:
![Screen Shot 2022-09-25 at 10 34 55 AM](https://user-images.githubusercontent.com/4925067/192157151-4a966e18-775f-46da-a425-117311b5fd23.png)

This change ensures that each unique violation is only returned once.
