### PR TITLE
Account for contents that are promises

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -242,7 +242,7 @@ export class Engine {
           }
 
           try {
-            await writeFile(filepath, file.contents);
+            await writeFile(filepath, await file.contents); // This seemingly unnecessary await accounts for an odd bug caused by generators using an older version (<=2) of prettier
           } catch (ex) {
             this.pushErrors({
               code: 'WRITE_ERROR',


### PR DESCRIPTION
In prettier v3, the format command now returns a promise, not a string. If a generator was written to consume an older version, but is provided v3+, the generator will run, but silently returning a promise. This prevents the formatted contents from being written.