### PR TITLE
Fix bugs in the core Engine

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -207,7 +207,9 @@ export class Engine {
   private async compare(file: File): Promise<FileStatus> {
     try {
       const previous = (await readFile(join(...file.path))).toString();
-      return areEquivalent(previous, file.contents) ? 'no-change' : 'modified';
+      return areEquivalent(previous, await file.contents)
+        ? 'no-change'
+        : 'modified';
     } catch {
       return 'added';
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -521,7 +521,7 @@ function areEquivalent(previous: string | null, next: string): boolean {
     const firstLineBreakPrevious = previous.indexOf('\n');
     if (firstLineBreakPrevious === -1) return false;
 
-    const firstLineBreakNext = previous.indexOf('\n');
+    const firstLineBreakNext = next.indexOf('\n');
     if (firstLineBreakNext === -1) return false;
 
     // If either the previous or next versions only contain whitespace after the first line break, then all of the significant differences must be on the first line


### PR DESCRIPTION
### Context

Some generators return `file.content` values that are promises. This is due to a major version update to Prettier that returns a promise instead of a string. The internal comparison between previous and next files always flagged these files as modified because the existing string on the file system was never equal to a Promise.

### Change

This change simply awaits the file contents. This is a no-op if the contents are a string, but correctly resolves Promises.

### Consequences

All files created by generators that (incorrectly) return Promises will be correctly labeled as "no change" if the re-generated contents are the same.