### PR TITLE
Resolve relative paths for get line

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -224,7 +224,7 @@ export class RpcEngine implements Engine {
     lineNumber: number,
   ): Promise<string> {
     if (!this._contentBySource.has(sourcePath)) {
-      const buffer = await this.fs.readFile(sourcePath);
+      const buffer = await this.fs.readFile(this.resolve(sourcePath));
       this._contentBySource.set(sourcePath, buffer.toString().split(EOL));
     }
     return this._contentBySource.get(sourcePath)![lineNumber - 1];
@@ -1026,7 +1026,7 @@ export class NodeEngine implements Engine {
     lineNumber: number,
   ): Promise<string> {
     if (!this._contentBySource.has(sourcePath)) {
-      const buffer = await this.fs.readFile(sourcePath);
+      const buffer = await this.fs.readFile(this.resolve(sourcePath));
       this._contentBySource.set(sourcePath, buffer.toString().split(EOL));
     }
     return this._contentBySource.get(sourcePath)![lineNumber - 1];


### PR DESCRIPTION
## Bug: `getLine` fails to read files due to unresolved relative paths

### Problem

The `getLine` method in both `RpcEngine` and `NodeEngine` fails to read source files when violations are reported because it attempts to read files using relative paths without resolving them to absolute paths first.

Root Cause:
In `pushViolations`, violation source paths are converted to relative paths:
- For violations with `sourcePath === '#'`, they're replaced with r`elative(projectDirectory, this.sourcePath)`
- Other violations may already contain relative paths

These relative paths (relative to the project directory) are then passed to `gerLine`, which directly calls `fs.readFile(sourcePath)`. However, `fs.readFile` expects either an absolute path or a path relative to the current working directory, not relative to the project directory.

Example:
- Project directory: `/Users/example/myproject`
- Source file: `/Users/example/myproject/api/schema.yaml`
- Relative path stored: `api/schema.yaml`
- When `fs.readFile('api/schema.yaml')` is called, it looks for the file relative to `process.cwd()`, not the project directory, causing a `file-not-found` error

### Solution
Resolve relative source paths to absolute paths before reading them using the existing `resolve()` method available in both engine classes:
- RpcEngine (line 227):

```ts
const buffer = await this.fs.readFile(this.resolve(sourcePath));
```

- NodeEngine (line 1029):

```ts
const buffer = await this.fs.readFile(this.resolve(sourcePath));
```

This ensures that the file system operations work correctly regardless of the current working directory.